### PR TITLE
Python2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,6 +118,9 @@ RUN apt-get update
 RUN apt-get install -y -t unstable gcc-5
 RUN apt-get install -y clang
 
+#Pylint for python 2
+RUN apt-get install -y python-pip
+RUN python2 -m pip install pylint
 
 WORKDIR /usr/src/app
 

--- a/src/linter-webapp.rb
+++ b/src/linter-webapp.rb
@@ -1,6 +1,6 @@
 require 'sinatra'
 require_relative 'linters/coala/java_linter'
-require_relative 'linters/coala/python_linter'
+require_relative 'linters/coala/python3_linter'
 require_relative 'linters/coala/cpp_linter'
 require_relative 'linters/coala/c_linter'
 
@@ -18,7 +18,7 @@ post "/java" do
 end
 
 post '/python' do
-  Coala::PythonLinter.new(params["code"]).perform_lint
+  Coala::Python3Linter.new(params["code"]).perform_lint
 end
 
 post '/c' do

--- a/src/linter-webapp.rb
+++ b/src/linter-webapp.rb
@@ -1,5 +1,6 @@
 require 'sinatra'
 require_relative 'linters/coala/java_linter'
+require_relative 'linters/coala/python2_linter'
 require_relative 'linters/coala/python3_linter'
 require_relative 'linters/coala/cpp_linter'
 require_relative 'linters/coala/c_linter'
@@ -15,6 +16,10 @@ end
 
 post "/java" do
   Coala::JavaLinter.new(params["code"]).perform_lint
+end
+
+post '/python2' do
+  Coala::Python2Linter.new(params["code"]).perform_lint
 end
 
 post '/python3' do

--- a/src/linter-webapp.rb
+++ b/src/linter-webapp.rb
@@ -17,7 +17,7 @@ post "/java" do
   Coala::JavaLinter.new(params["code"]).perform_lint
 end
 
-post '/python' do
+post '/python3' do
   Coala::Python3Linter.new(params["code"]).perform_lint
 end
 

--- a/src/linters/coala/python2_linter.rb
+++ b/src/linters/coala/python2_linter.rb
@@ -1,0 +1,10 @@
+require_relative "python_linter"
+
+module Coala
+  class Python2Linter < PythonLinter
+    def results
+        json_coala = `coala -I --files #{@file_absolute_path} --bears PyLintBear2 --json`
+        Coala::JsonConverter.convert_json_from_coala_to_codemirror(json_coala)
+    end
+  end
+end

--- a/src/linters/coala/python3_linter.rb
+++ b/src/linters/coala/python3_linter.rb
@@ -1,0 +1,10 @@
+require_relative "python_linter"
+
+module Coala
+  class Python3Linter < PythonLinter
+    def results
+        json_coala = `coala -I --files #{@file_absolute_path} --bears PyLintBear --json`
+        Coala::JsonConverter.convert_json_from_coala_to_codemirror(json_coala)
+    end
+  end
+end

--- a/src/linters/coala/python_linter.rb
+++ b/src/linters/coala/python_linter.rb
@@ -3,11 +3,6 @@ require_relative 'json_converter'
 
 module Coala
   class PythonLinter < ::AbstractLinter
-    def results
-      json_coala = `coala -I --files #{@file_absolute_path} --bears PyLintBear --json`
-      Coala::JsonConverter.convert_json_from_coala_to_codemirror(json_coala)
-    end
-
     def extension
       ".py"
     end


### PR DESCRIPTION
This PR adds the functionality to treat python2 and python3 as two separated languages.

Changes
* Install pylint for python2 on Dockerfile
* Refactor PythonLinter and create Python3Linter and Python2Linter
* Add the new endpoints
 